### PR TITLE
perf:调整日志级别至info,屏蔽使用中产生的swoole trace日志

### DIFF
--- a/watch
+++ b/watch
@@ -69,7 +69,7 @@ use Swoole\Process;
 use Swoole\Timer;
 use Swoole\Event;
 
-swoole_async_set(['enable_coroutine' => false]);
+swoole_async_set(['enable_coroutine' => false, 'log_level' => SWOOLE_LOG_INFO]);
 $hashes = [];
 $serve = null;
 echo "🚀 Start @ " . date('Y-m-d H:i:s') . PHP_EOL;


### PR DESCRIPTION
# 说明
swoole编译时如果开启了--enable-trace-log后，会输出大片的swoole trace log，导致我看不到项目正常的日志输出，所以建议默认把watch中的swoole日志级别调整成info级别。
![image](https://user-images.githubusercontent.com/2928867/71500175-c8fa1d80-289e-11ea-9fa3-4cdde5e90d33.png)
